### PR TITLE
TOMEE-2078 - Fix menu

### DIFF
--- a/src/main/jbake/content/examples/index.adoc
+++ b/src/main/jbake/content/examples/index.adoc
@@ -1,5 +1,0 @@
-= Examples
-:jbake-date: 2016-08-30
-:jbake-type: examples
-:jbake-status: published
-:jbake-tomeepdf:

--- a/src/main/jbake/templates/menu.gsp
+++ b/src/main/jbake/templates/menu.gsp
@@ -27,7 +27,7 @@
 			<div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
 				<ul class="nav navbar-nav navbar-right main-nav">
 					<li><a href="<%if (content.rootpath) {%>${content.rootpath}<% } else { %><% }%>docs.html">Documentation</a></li>
-					<li><a href="<%if (content.rootpath) {%>${content.rootpath}<% } else { %><% }%>examples/index.html">Examples</a></li>
+					<li><a href="<%if (content.rootpath) {%>${content.rootpath}<% } else { %><% }%>examples/index-ng.html">Examples</a></li>
 					<li><a href="<%if (content.rootpath) {%>${content.rootpath}<% } else { %><% }%>community/index.html">Community</a></li>
 					<li><a href="<%if (content.rootpath) {%>${content.rootpath}<% } else { %><% }%>security/index.html">Security</a></li>
 					<li><a href="<%if (content.rootpath) {%>${content.rootpath}<% } else { %><% }%>download-ng.html">Downloads</a></li>


### PR DESCRIPTION
This is just a small fix as the menu was pointing to examples/index.html (which in ASF infra stands for the old site) and now will point to examples/index-ng.html (new site).

