### PR TITLE
Update Links in Commercial Support Page

### DIFF
--- a/src/main/jbake/content/community/commercial.adoc
+++ b/src/main/jbake/content/community/commercial.adoc
@@ -16,7 +16,7 @@ https://www.tomitribe.com[Tomitribe] is a company created by several founding me
 
 == ManageCat
 
-ManageCat is a cloud management and service platform for Apache Tomcat and Apache TomEE servers. Involving with a lot of Apache Java EE projects, we want to transfer not only our knowledge about Apache TomEE and also other Java EE technologies including JPA, EJB, CDI, JSF, JSTL, JTA, JMS. We will help our customers to develop and deploy their production based Java EE applications smoothly.
+https://www.managecat.com[ManageCat] is a cloud management and service platform for Apache Tomcat and Apache TomEE servers. Involving with a lot of Apache Java EE projects, we want to transfer not only our knowledge about Apache TomEE and also other Java EE technologies including JPA, EJB, CDI, JSF, JSTL, JTA, JMS. We will help our customers to develop and deploy their production based Java EE applications smoothly.
 
 == I want to be added there
 

--- a/src/main/jbake/content/security/support.adoc
+++ b/src/main/jbake/content/security/support.adoc
@@ -30,4 +30,4 @@ If you encounter a bug or want to submit a patch just go on our https://issues.a
 
 == Commercial Support
 
-If you need advanced support with SLA please have a look to our xref:community/commercial.adoc[Commercial] page.
+If you need advanced support with SLA please have a look to our xref:../community/commercial.adoc[Commercial] page.


### PR DESCRIPTION
**What this PR Does?**
1. The commercial support link in page [https://tomee.apache.org/security/support.html](https://tomee.apache.org/security/support.html) is broken. This PR fixes it.
2. There is href link in ManageCat text in commercial support as Tomitribe does. This PR improves this.

Hope to merge this PR as soon as possible and publish into website.

Regards.
Gurkan