### PR TITLE
Add version placeholder

### DIFF
--- a/src/main/java/org/apache/tomee/website/Source.java
+++ b/src/main/java/org/apache/tomee/website/Source.java
@@ -68,6 +68,7 @@ public class Source {
     private File dir;
     private Filter javadocFilter = new Filter(".*/src/main/java/.*", ".*/(tck|itests|examples|archetype-resources|.*-example)/.*");
     private Pattern javadocPackages;
+    private String version;
 
     /**
      * This allows us to attach a handful of finishing actions to
@@ -98,6 +99,11 @@ public class Source {
         this.branch = branch;
         this.name = name;
         this.latest = latest;
+    }
+
+    public Source(final String scmUrl, final String branch, final String name, final boolean latest, final String version) {
+        this(scmUrl, branch, name, latest);
+        this.version = version;
     }
 
     public List<Runnable> getPerform() {
@@ -180,6 +186,15 @@ public class Source {
 
     public Source label(final String label) {
         this.label = label;
+        return this;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public Source version(final String version) {
+        this.version = version;
         return this;
     }
 

--- a/src/main/java/org/apache/tomee/website/Sources.java
+++ b/src/main/java/org/apache/tomee/website/Sources.java
@@ -126,6 +126,7 @@ public class Sources {
         final VersionIndex versionIndex = new VersionIndex(this);
         final LearningLinks learningLinks = new LearningLinks(examples);
         final Jakartize jakartize = new Jakartize();
+        final TomEEVersionReplacement versionReplacement = new TomEEVersionReplacement();
 
         try {
             IO.copyDirectory(mainSource, jbake);
@@ -144,6 +145,7 @@ public class Sources {
         // source root (excluding the related repos)
         sources.stream()
                 .peek(jakartize::prepare)
+                .peek(versionReplacement::prepare)
                 .peek(docs::prepare)
                 .peek(javadocs::prepare)
                 .peek(examples::prepare)

--- a/src/main/java/org/apache/tomee/website/TomEEVersionReplacement.java
+++ b/src/main/java/org/apache/tomee/website/TomEEVersionReplacement.java
@@ -49,7 +49,7 @@ public class TomEEVersionReplacement {
     private void replaceVersions(final File file, final String version) {
         try {
             final InputStream inputStream = StreamBuilder.create(IO.read(file))
-                    .replace("${tomee.version}", version)
+                    .replace("${TOMEE_VERSION}", version)
                     .get();
 
             final String content = IO.slurp(inputStream);

--- a/src/main/java/org/apache/tomee/website/TomEEVersionReplacement.java
+++ b/src/main/java/org/apache/tomee/website/TomEEVersionReplacement.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.tomee.website;
+
+import org.tomitribe.swizzle.stream.StreamBuilder;
+import org.tomitribe.tio.Dir;
+import org.tomitribe.util.IO;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+
+/**
+ * This class simply looks to replace any instances of ${tomee.version} with the version from the source.
+ */
+public class TomEEVersionReplacement {
+
+    public void prepare(final Source source) {
+        final String version = source.getVersion();
+        if (version == null || version.trim().length() == 0) return;
+
+        final Dir dir = Dir.from(source.getDir());
+        dir.searchFiles()
+                .filter(File::isFile)
+                .filter(this::isDocsOrExamples)
+                .forEach(f -> this.replaceVersions(f, version));
+    }
+
+    private boolean isDocsOrExamples(final File file) {
+        final String path = file.getAbsolutePath();
+        return path.contains("/docs/") || path.contains("/examples/");
+    }
+
+    private void replaceVersions(final File file, final String version) {
+        try {
+            final InputStream inputStream = StreamBuilder.create(IO.read(file))
+                    .replace("${tomee.version}", version)
+                    .get();
+
+            final String content = IO.slurp(inputStream);
+            IO.copy(IO.read(content), file);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to process file: " + file.getAbsolutePath(), e);
+        }
+
+    }
+}


### PR DESCRIPTION
Allow a config to specify a TomEE version, and any instances of ${tomee.version} to be replaced with the version number when building the site.