### PR TITLE
Improve compatibility matrix to include DeltaSpike as an Apache alternative to Spring Data JPA

### DIFF
--- a/src/main/jbake/content/comparison.adoc
+++ b/src/main/jbake/content/comparison.adoc
@@ -149,17 +149,20 @@ https://smallrye.io/[SmallRye MicroProfile^] *(ok with TomEE 9.x and later)*
 
 In bold : Implementations that differ between flavors or between versions
 
-== [[Compatibility]] Compatibility with other implementations
+== [[Compatibility]] Implementations compatibility and alternatives
 
-[options="header",cols="1,1"]
+[options="header",cols="6,10,5"]
 |===
-|Specifications|Implementations alternatives +
-//(see icons for compatibilities with TomEE)
-|Jakarta Persistence (JPA)|https://hibernate.org/orm/[Hibernate ORM^] {y} +
-|Jakarta MVC|
+|Features|Implementations|Alternatives
+|https://jakarta.ee/specifications/mvc/[Jakarta MVC^] (Controllers)|
 https://eclipse-ee4j.github.io/krazo/[Eclipse Krazo^] {y} *(ok with TomEE 8.x and later)* +
-|Other containers (CDI, EJB, JTA, etc.) and frameworks|
-https://spring.io/[Spring^] {y} +
-|===
+https://spring.io/[Spring Web MVC^] {y} +
+||https://jakarta.ee/specifications/data/[Jakarta Data^] (Repositories)|
+{n} no api nor implementations released yet|
+https://deltaspike.apache.org/[Apache DeltaSpike^] {y} +
+https://spring.io/[Spring Data JPA^] {y} +
+|https://jakarta.ee/specifications/persistence/[Jakarta Persistence] (ORM)|
+https://hibernate.org/orm/[Hibernate ORM^] {y} +
+||===
 
-* Please note that TomEE does not ship with the jars for Hibernate, Jersey, Krazo, Spring.
+* Please note that TomEE does not ship with the jars for DeltaSpike, Hibernate, Jersey, Krazo, Spring.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5782559/209665306-35f0e4b7-478d-4ba2-9543-b8512fe21477.png)
